### PR TITLE
Get cart two types

### DIFF
--- a/client/components/SingleWine/SingleWine.js
+++ b/client/components/SingleWine/SingleWine.js
@@ -1,4 +1,5 @@
 import React, {Component} from 'react'
+import SingleWineQuantityForm from './SingleWineQuantityForm'
 
 const SingleWine = props => {
   const wine = props.wine
@@ -14,9 +15,9 @@ const SingleWine = props => {
       </p>
       <img src={imageURL} />
       <p>Color: {color} </p>
-      <button type="button" onClick={props.clickHandler}>
-        Add to Cart
-      </button>
+      <SingleWineQuantityForm
+        getQuantity={quantity => props.clickHandler(quantity)}
+      />
     </div>
   )
 }

--- a/client/components/SingleWine/SingleWineContainer.js
+++ b/client/components/SingleWine/SingleWineContainer.js
@@ -1,7 +1,7 @@
 import React, {Component} from 'react'
 import {connect} from 'react-redux'
 import NProgress from 'nprogress'
-import {fetchWine, addToCart} from '../../store'
+import {fetchWine, pushToCart} from '../../store'
 import SingleWine from './SingleWine'
 
 export class SingleWineContainer extends Component {
@@ -10,9 +10,9 @@ export class SingleWineContainer extends Component {
     this.clickHandler = this.clickHandler.bind(this)
   }
 
-  clickHandler() {
+  clickHandler(quantity) {
     NProgress.start()
-    this.props.addToCart(this.props.match.params.wineId)
+    this.props.pushToCart(this.props.match.params.wineId, quantity)
     NProgress.done()
   }
   componentDidMount() {
@@ -32,7 +32,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
   fetchWine: id => dispatch(fetchWine(id)),
-  pushToCart: id => dispatch(pushToCart(id))
+  pushToCart: (id, quantity) => dispatch(pushToCart(id, quantity))
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(SingleWineContainer)

--- a/client/components/SingleWine/SingleWineQuantityForm.js
+++ b/client/components/SingleWine/SingleWineQuantityForm.js
@@ -1,0 +1,41 @@
+import React, {Component} from 'react'
+
+export default class SingleWineQuantityForm extends Component {
+  constructor() {
+    super()
+    this.state = {
+      quantity: 1
+    }
+    this.handleChange = this.handleChange.bind(this)
+    this.handleSubmit = this.handleSubmit.bind(this)
+  }
+
+  handleChange(event) {
+    this.setState({
+      quantity: event.target.value
+    })
+  }
+
+  handleSubmit(event) {
+    event.preventDefault()
+    this.props.getQuantity(this.state.quantity)
+    this.setState({
+      quantity: 1
+    })
+  }
+
+  render() {
+    return (
+      <form onSubmit={this.handleSubmit}>
+        <select onChange={this.handleChange} value={this.state.quantity}>
+          {Array.from({length: 10}, (v, k) => k + 1).map(val => (
+            <option key={val} value={val}>
+              {val}
+            </option>
+          ))}
+        </select>
+        <button type="submit">Add to Cart</button>
+      </form>
+    )
+  }
+}

--- a/client/store/cart.js
+++ b/client/store/cart.js
@@ -24,24 +24,23 @@ const ADD_TO_CART = 'ADD_TO_CART'
 /**
  * ACTION CREATORS
  */
-export const addToCart = id => {
-  console.log('i am add to cart!')
+export const addToCart = (id, quantity) => {
   return {
     type: ADD_TO_CART,
-    id
+    id,
+    quantity
   }
 }
 
 /**
  * THUNK CREATORS
  */
-export const pushToCart = wineId => async dispatch => {
+export const pushToCart = (wineId, quantity) => async dispatch => {
   try {
     if (user) {
-      const test = await axios.post(`/api/cart/${wineId}`)
-      console.log('TEST', test.data.wines)
+      await axios.post(`/api/cart/${wineId}`, {quantity})
     }
-    dispatch(addToCart(wineId))
+    dispatch(addToCart(wineId, quantity))
   } catch (err) {
     console.error(err)
   }
@@ -55,11 +54,12 @@ export default function(state = initialCart, action) {
     // add to cart NOT logged in
     case ADD_TO_CART: {
       const id = action.id
+      const quantity = +action.quantity
       const copy = {...state}
       if (copy[id]) {
-        copy[id]++
+        copy[id] += quantity
       } else {
-        copy[id] = 1
+        copy[id] = quantity
       }
       return copy
     }

--- a/client/store/cart.spec.js
+++ b/client/store/cart.spec.js
@@ -14,38 +14,47 @@ import {addToCart, pushToCart} from './index' // action/thunk creators
 
 describe('cart reducer', () => {
   const id = 15
+  const quantity = 3
 
   describe('action creators', () => {
     describe('addToCart', () => {
       it('returns properly formatted action', () => {
-        expect(addToCart(id)).to.be.deep.equal({
+        console.log(addToCart(id, quantity))
+        expect(addToCart(id, quantity)).to.be.deep.equal({
           type: 'ADD_TO_CART',
-          id
+          id,
+          quantity: 3
         })
       })
     })
   })
 
-  //   describe('thunk creators', () => {
-  //     let store
-  //     let mockAxios
-  //     beforeEach(() => {
-  //       mockAxios = new MockAdapter(axios)
-  //       store = mockStore(initialState)
-  //     })
+  describe('thunk creators', () => {
+    let store
+    let mockAxios
+    beforeEach(() => {
+      mockAxios = new MockAdapter(axios)
+      store = mockStore(initialState)
+    })
 
-  //     afterEach(() => {
-  //       mockAxios.restore()
-  //       store.clearActions()
-  //     })
-  //     describe('pushToCart', () => {
-  //       it('eventually dispatches the ADD TO CART action', async () => {
-  //         mockAxios.onGet('/api/wines/1').replyOnce(200, id)
-  //         await store.dispatch(pushToCart(1))
-  //         const actions = store.getActions()
-  //         expect(actions[0].type).to.equal('ADD_TO_CART')
-  //         expect(actions[0].payload).to.deep.equal(id)
-  //       })
-  //     })
-  //   })
+    afterEach(() => {
+      mockAxios.reset()
+      store.clearActions()
+    })
+
+    after(() => {
+      mockAxios.restore()
+    })
+
+    describe('pushToCart', () => {
+      it('eventually dispatches the ADD TO CART action', async () => {
+        mockAxios.onPost('/api/cart/1', {quantity}).replyOnce(201)
+        await store.dispatch(pushToCart(1, quantity))
+        const actions = store.getActions()
+        expect(actions[0].type).to.equal('ADD_TO_CART')
+        expect(actions[0].id).to.equal(1)
+        expect(actions[0].quantity).to.equal(quantity)
+      })
+    })
+  })
 })

--- a/server/api/cart.js
+++ b/server/api/cart.js
@@ -1,44 +1,26 @@
 const router = require('express').Router()
-const {Wine} = require('../db/models')
+const {Wine, Order} = require('../db/models')
 const {isAuthenticated} = require('./index')
 module.exports = router
 
-const getCart = async req => {
-  const [order] = await req.user.getOrders({
-    where: {status: 'open'},
-    include: [Wine]
-  })
-  return order
-}
-
-const getBareCart = userCart => {
-  const cart = {}
-  userCart.wines.forEach(wine => {
-    cart[wine.id] = wine['order-item'].quantity
-  })
-  return cart
-}
-
-const getSpecificWine = req => {
-  return req.cart
-    .getWines({
-      where: {id: req.params.wineId}
-    })
-    .then(([wine]) => {
-      return wine
-    })
-}
-
-// for all methods
+// for all methods in this route, attach the appropriate cart to req.cart
 router.all('/*', isAuthenticated, async (req, res, next) => {
-  req.cart = await getCart(req)
+  req.cart = await req.user.getCart()
   next()
 })
 
 // get all items in cart
-router.get('/', (req, res, next) => {
+router.get('/', async (req, res, next) => {
   try {
-    res.json(getBareCart(req.cart))
+    const complete = req.query.complete
+    if (!complete) {
+      // if undefined or explicitly set to false
+      // the bare version is just an object of the form { wineId: quantity }
+      res.json(await req.cart.getBareVersion())
+    } else {
+      // otherwise it includes the cart and eager loads the wines with their quantity
+      res.json(await req.cart.getCompleteVersion())
+    }
   } catch (err) {
     next(err)
   }
@@ -46,10 +28,10 @@ router.get('/', (req, res, next) => {
 
 router.post('/:wineId', async (req, res, next) => {
   try {
-    const hasWine = await req.cart.hasWine(req.params.id)
+    const hasWine = await req.cart.hasWine(req.params.wineId)
     if (hasWine) {
-      const wineToUpdate = await getSpecificWine(req)
-      wineToUpdate['order-item'].quantity = wineToUpdate.quantity + 1
+      const wineToUpdate = await req.cart.getWineById(req.params.wineId)
+      wineToUpdate['order-item'].quantity++
       await wineToUpdate['order-item'].save()
     } else {
       await req.cart.addWine(req.params.wineId, {
@@ -66,7 +48,7 @@ router.post('/:wineId', async (req, res, next) => {
 
 router.put('/:wineId', async (req, res, next) => {
   try {
-    const wineToUpdate = await getSpecificWine(req)
+    const wineToUpdate = await req.cart.getWineById(req.params.wineId)
     wineToUpdate['order-item'].quantity = req.body.quantity
     await wineToUpdate['order-item'].save()
     res.sendStatus(202)

--- a/server/api/cart.spec.js
+++ b/server/api/cart.spec.js
@@ -81,6 +81,18 @@ describe('Cart routes', () => {
       })
     })
 
+    it('GET /api/cart/?complete=true', async () => {
+      const res = await request(app)
+        .get('/api/cart/?complete=true')
+        .expect(200)
+
+      expect(res.body.id).to.equal(1)
+      expect(res.body.wines[1].name).to.equal(
+        'Cantina Furlani - Sur Lie Rosato NV'
+      )
+      expect(res.body.wines[1]['order-item'].quantity).to.equal(2)
+    })
+
     it('POST /api/cart/:wineId', async () => {
       const res = await request(app)
         .post('/api/cart/3')

--- a/server/db/models/index.js
+++ b/server/db/models/index.js
@@ -18,6 +18,30 @@ Order.belongsToMany(Wine, {through: OrderItem})
 Order.belongsTo(User)
 User.hasMany(Order)
 
+User.prototype.getCart = async function() {
+  const [order] = await this.getOrders({
+    where: {status: 'open'},
+    include: [Wine]
+  })
+  return order
+}
+
+Order.prototype.getWineById = async function(id) {
+  const [wine] = await this.getWines({
+    where: {id}
+  })
+  return wine
+}
+
+Order.prototype.getBareVersion = async function() {
+  const wines = await this.getWines()
+  const cart = {}
+  wines.forEach(wine => {
+    cart[wine.id] = wine['order-item'].quantity
+  })
+  return cart
+}
+
 module.exports = {
   User,
   Wine,

--- a/server/db/models/orders.js
+++ b/server/db/models/orders.js
@@ -1,5 +1,6 @@
 const Sequelize = require('sequelize')
 const db = require('../db')
+const Wine = require('./wine')
 
 const Order = db.define('order', {
   total: {
@@ -12,5 +13,14 @@ const Order = db.define('order', {
 })
 
 module.exports = Order
+
+/**
+ * instanceMethods
+ */
+Order.prototype.getCompleteVersion = function() {
+  return Order.findById(this.id, {
+    include: [Wine]
+  })
+}
 
 // making a change so I can make a new commit


### PR DESCRIPTION
By two types, I mean a "bare" version of the cart and a "complete" version can be sent from the backend.

The bare version is just an object where the key is the `wineId` and the value is its `quantity`

The complete version is the cart (order) object, with its wines eager loaded. I think this version is only necessary when rendering the cart. The bare version would be nice for updating the cart.

we can possibly update our store `cart` to be an object with two keys `bare` and `complete`